### PR TITLE
Relax Qt pinnings

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,8 @@ source:
     folder: {{ name }}
 
 build:
-  number: 0
+  number: 1
+  # https://doc.qt.io/qt-6/qt-releases.html#binary-compatibility
   run_exports:
     - {{ pin_subpackage(name, max_pin='x.x') }}
 
@@ -35,9 +36,6 @@ requirements:
     - qtbase-devel {{ version }}
     - libtiff {{ libtiff }}
     - libwebp {{ libwebp }}
-  run_constrained:
-    - qt-main >={{ version }},<7
-    - qt >={{ version }},<7
 
 test:
   commands:


### PR DESCRIPTION
qtimageformats 6.9.2 b1

**Destination channel:** defaults

### Links

- [PKG-7628](https://anaconda.atlassian.net/browse/PKG-7628)

### Explanation of changes:

- Qt binary compatibility says you can run with any v6.x.x that is >= what you built against.
- Remove run constraints on meta packages since they already dictate which Qt versions get installed.

[PKG-7628]: https://anaconda.atlassian.net/browse/PKG-7628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ