### PR TITLE
qtimageformats 6.10.2

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/pbp/fs/qtbase-feedstock/pr21/901c992

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/pbp/fs/qtbase-feedstock/pr21/901c992

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "qtimageformats" %}
-{% set version = "6.10.1" %}
+{% set version = "6.10.2" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   - url: https://download.qt.io/official_releases/qt/{{ version.rpartition('.')[0] }}/{{ version }}/submodules/{{ name }}-everywhere-src-{{ version }}.tar.xz
-    sha256: 498eabdf2381db96f808942b3e3c765f6360fe6c0e9961f0a45ff7a4c68d7a72
+    sha256: 8b8f9c718638081e7b3c000e7f31910140b1202a98e98df5d1b496fe6f639d67
     folder: {{ name }}
 
 build:


### PR DESCRIPTION
qtimageformats 6.10.2

**Destination channel:** defaults

### Links

- [PKG-12482](https://anaconda.atlassian.net/browse/PKG-12482) 

### Explanation of changes:

- Version update


[PKG-12482]: https://anaconda.atlassian.net/browse/PKG-12482?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ